### PR TITLE
Support Passing Command Line Arguments Into Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ In order to run a task, run the following command in your terminal:
 poetry run task test
 ```
 
+### Passing Command Line Args to Tasks
+If you want to pass command line arguments to tasks (positional or named), simply append them to the end of the task command.
+
+For example, running the above task like this:
+```bash
+poetry run task test -h
+```
+
+Is equivalent to running:
+```bash
+python -m unittest tests/test_*.py -h
+```
+
+And will show unittest's help instead of actually running it.
+
+> ⚠️ Note: if you are using pre \ post hooks, do notice that arguments are not passed to them, only to the task itself.
+
 ### Composing Tasks
 #### Grouping Subtasks Together
 Some tasks are composed of multiple subtasks. Instead of writing plain shell commands and stringing them together, you can break them down into multiple subtasks:

--- a/taskipy/cli.py
+++ b/taskipy/cli.py
@@ -5,9 +5,10 @@ from taskipy.run import run_task
 def main():
     parser = argparse.ArgumentParser(prog='task', description='runs a task specified in your pyproject.toml under [tool.taskipy.tasks]')
     parser.add_argument('name', help='name of the task')
+    parser.add_argument('args', nargs=argparse.REMAINDER, help='arguments to pass to the task')
     args = parser.parse_args()
 
-    run_task(args.name)
+    run_task(args.name, args.args)
 
 if __name__ == '__main__':
     main()

--- a/taskipy/run.py
+++ b/taskipy/run.py
@@ -5,7 +5,7 @@ import toml
 from os import path
 from typing import List
 
-def run_task(task_name: str, cwd=os.curdir):
+def run_task(task_name: str, args: List[str], cwd=os.curdir):
     def run_commands_and_bail_on_first_fail(cmds: List[str]) -> int:
         for cmd in cmds:
             p = subprocess.Popen(cmd, shell=True, cwd=cwd)
@@ -34,7 +34,8 @@ def run_task(task_name: str, cwd=os.curdir):
 
     try:
         task = tasks[task_name]
-        commands.append(task)
+        command_with_passed_args = ' '.join([task] + args)
+        commands.append(command_with_passed_args)
     except:
         print(f'could not find task "{task_name}""')
         sys.exit(127)

--- a/tests/fixtures/project_with_tasks_that_accept_arguments/count.sh
+++ b/tests/fixtures/project_with_tasks_that_accept_arguments/count.sh
@@ -1,0 +1,1 @@
+echo the argument count is $#

--- a/tests/fixtures/project_with_tasks_that_accept_arguments/pyproject.toml
+++ b/tests/fixtures/project_with_tasks_that_accept_arguments/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+echo_number = "echo the number is "
+echo_named = "echo got a named argument "
+echo_args_count = "bash count.sh"
+
+pre_echo_on_prehook = "echo the number in prehook is "
+echo_on_prehook = "echo ok"
+
+echo_on_posthook = "echo ok"
+post_echo_on_posthook = "echo the number in posthook is "


### PR DESCRIPTION
## Description
Passing command line arguments into tasks is now possible, and they will appended to the command that is run by the task.

For further explanation, take a look at the new section in the README file.

## Changes
1. `run_task` now expects an `args` list, and passes it into the task's subprocess. (`taskipy.run`)
2. the argument parser now intercepts the remainder of the args (everything after the task name) and passes them into `run_task` as `args` (`taskipy.cli`)
3. added tests which cover multiple scenarios (`tests.test_taskipy`)

> This feature was originally requested [here](https://github.com/illBeRoy/taskipy/issues/1).