### PR TITLE
Ignore SIGINT While Running Tasks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -80,6 +80,17 @@ version = "0.4.3"
 
 [[package]]
 category = "dev"
+description = "Cross-platform lib for process and system monitoring in Python."
+name = "psutil"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "5.6.7"
+
+[package.extras]
+enum = ["enum34"]
+
+[[package]]
+category = "dev"
 description = "python code static checker"
 name = "pylint"
 optional = false
@@ -141,7 +152,7 @@ python-versions = "*"
 version = "1.11.2"
 
 [metadata]
-content-hash = "c9a9ad81a21b3edfe2b0695af814eaf3974c6fca8a4d1913f666eaabd432f72e"
+content-hash = "038310699e756391b0ed0ae9e0597be14230fd9972a32aadc8afb80544a1f2e0"
 python-versions = "^3.5"
 
 [metadata.files]
@@ -203,6 +214,19 @@ mypy = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+psutil = [
+    {file = "psutil-5.6.7-cp27-none-win32.whl", hash = "sha256:1b1575240ca9a90b437e5a40db662acd87bbf181f6aa02f0204978737b913c6b"},
+    {file = "psutil-5.6.7-cp27-none-win_amd64.whl", hash = "sha256:28f771129bfee9fc6b63d83a15d857663bbdcae3828e1cb926e91320a9b5b5cd"},
+    {file = "psutil-5.6.7-cp35-cp35m-win32.whl", hash = "sha256:21231ef1c1a89728e29b98a885b8e0a8e00d09018f6da5cdc1f43f988471a995"},
+    {file = "psutil-5.6.7-cp35-cp35m-win_amd64.whl", hash = "sha256:b74b43fecce384a57094a83d2778cdfc2e2d9a6afaadd1ebecb2e75e0d34e10d"},
+    {file = "psutil-5.6.7-cp36-cp36m-win32.whl", hash = "sha256:e85f727ffb21539849e6012f47b12f6dd4c44965e56591d8dec6e8bc9ab96f4a"},
+    {file = "psutil-5.6.7-cp36-cp36m-win_amd64.whl", hash = "sha256:b560f5cd86cf8df7bcd258a851ca1ad98f0d5b8b98748e877a0aec4e9032b465"},
+    {file = "psutil-5.6.7-cp37-cp37m-win32.whl", hash = "sha256:094f899ac3ef72422b7e00411b4ed174e3c5a2e04c267db6643937ddba67a05b"},
+    {file = "psutil-5.6.7-cp37-cp37m-win_amd64.whl", hash = "sha256:fd2e09bb593ad9bdd7429e779699d2d47c1268cbde4dda95fcd1bd17544a0217"},
+    {file = "psutil-5.6.7-cp38-cp38-win32.whl", hash = "sha256:70387772f84fa5c3bb6a106915a2445e20ac8f9821c5914d7cbde148f4d7ff73"},
+    {file = "psutil-5.6.7-cp38-cp38-win_amd64.whl", hash = "sha256:10b7f75cc8bd676cfc6fa40cd7d5c25b3f45a0e06d43becd7c2d2871cbb5e806"},
+    {file = "psutil-5.6.7.tar.gz", hash = "sha256:ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa"},
 ]
 pylint = [
     {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = [
 task = 'taskipy.cli:main'
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 toml = "^0.10.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ toml = "^0.10.0"
 pylint = "^2.4.4"
 mypy = "^0.761"
 rope = "^0.14.0"
+psutil = "^5.6.7"
 
 [tool.taskipy.tasks]
 test = "python -m unittest -v tests/test_*.py"

--- a/taskipy/run.py
+++ b/taskipy/run.py
@@ -9,7 +9,12 @@ def run_task(task_name: str, args: List[str], cwd=os.curdir):
     def run_commands_and_bail_on_first_fail(cmds: List[str]) -> int:
         for cmd in cmds:
             p = subprocess.Popen(cmd, shell=True, cwd=cwd)
-            p.wait()
+
+            try:
+                p.wait()
+            except KeyboardInterrupt:
+                pass
+
             if p.returncode != 0:
                 return p.returncode
 
@@ -22,7 +27,6 @@ def run_task(task_name: str, args: List[str], cwd=os.curdir):
         sys.exit(1)
     except toml.TomlDecodeError:
         print('pyproject.toml file is malformed and could not be read')
-        # should print exception details
         sys.exit(1)
 
     try:

--- a/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_with_sigint_handler.py
+++ b/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_with_sigint_handler.py
@@ -1,0 +1,11 @@
+import time
+
+def main():
+    try:
+        while True:
+            time.sleep(.1)
+    except KeyboardInterrupt:
+        print('failing gracefully...')
+
+if __name__ == '__main__':
+    main()

--- a/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_without_sigint_handler.py
+++ b/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_without_sigint_handler.py
@@ -1,8 +1,12 @@
 import time
+import sys
 
 def main():
-    while True:
-        time.sleep(.1)
+    try:
+        while True:
+            time.sleep(.1)
+    except:
+        sys.exit(130)
 
 if __name__ == '__main__':
     main()

--- a/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_without_sigint_handler.py
+++ b/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_without_sigint_handler.py
@@ -1,0 +1,8 @@
+import time
+
+def main():
+    while True:
+        time.sleep(.1)
+
+if __name__ == '__main__':
+    main()

--- a/tests/fixtures/project_with_tasks_that_handle_interrupts/pyproject.toml
+++ b/tests/fixtures/project_with_tasks_that_handle_interrupts/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+run_loop_with_interrupt_handling = "python3 loop_with_sigint_handler.py"
+run_loop_without_interrupt_handling = "python3 loop_without_sigint_handler.py"

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -190,8 +190,11 @@ class InterruptingTaskTestCase(TaskipyTestCase):
 
     def interrupt_task(self, process: subprocess.Popen):
         psutil_process_wrapper = psutil.Process(process.pid)
+
         processes = psutil_process_wrapper.children(recursive=True)
-        processes[0].send_signal(signal.SIGINT)
+
+        innermost_process = next(filter(lambda p: p.name().startswith('python'), processes))
+        innermost_process.send_signal(signal.SIGINT)
 
     def test_handling_sigint_according_to_subprocess_if_it_handles_it_gracefully(self):
         cwd = self.create_test_dir_from_fixture('project_with_tasks_that_handle_interrupts')
@@ -214,4 +217,4 @@ class InterruptingTaskTestCase(TaskipyTestCase):
 
         exit_code = process.wait()
 
-        self.assertEqual(exit_code, 254)
+        self.assertEqual(exit_code, 130)


### PR DESCRIPTION
## Description
When running tasks, taskipy should be as non-intrusive as possible. Therefore, it should ignore interrupt signals (SIGINT) which are sent to the task process, and simply reflect its results as it would if the process ended for any other reasons.

A counter example for this behavior was demonstrated in [this issue](https://github.com/illBeRoy/taskipy/issues/7), where taskipy would ungracefully exit on interrupt even though the task process handled it perfectly.

## Changes
1. Wrote test cases covering interrupts sent to task processes
2. Added `psutil` as dev dependency for handling child processes during tests
3. Function: `run_commands_and_bail_on_first_fail` now ignores interrupts while running child processes