### PR TITLE
Passed Arguments Are Escaped Properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ share/python-wheels/
 *.egg
 MANIFEST
 .mypy_cache
+.idea

--- a/taskipy/run.py
+++ b/taskipy/run.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import toml
+import shlex
 from os import path
 from typing import List
 
@@ -46,7 +47,7 @@ def run_task(task_name: str, args: List[str], cwd=os.curdir):
         print(f'could not find task "{task_name}""')
         sys.exit(127)
 
-    command_with_passed_args = ' '.join([task] + args)
+    command_with_passed_args = ' '.join([task, shlex.join(args)])
     commands.append(command_with_passed_args)
 
     try:

--- a/taskipy/run.py
+++ b/taskipy/run.py
@@ -47,7 +47,7 @@ def run_task(task_name: str, args: List[str], cwd=os.curdir):
         print(f'could not find task "{task_name}""')
         sys.exit(127)
 
-    command_with_passed_args = ' '.join([task, shlex.join(args)])
+    command_with_passed_args = ' '.join([task] + [shlex.quote(arg) for arg in args])
     commands.append(command_with_passed_args)
 
     try:

--- a/tests/fixtures/project_with_task_that_checks_args_passed_with_spaces/identify.py
+++ b/tests/fixtures/project_with_task_that_checks_args_passed_with_spaces/identify.py
@@ -1,0 +1,8 @@
+import argparse
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--full-name')
+    parser.add_argument('--age')
+    args = parser.parse_args()
+    print(f'name: {args.full_name} age: {args.age}')

--- a/tests/fixtures/project_with_task_that_checks_args_passed_with_spaces/pyproject.toml
+++ b/tests/fixtures/project_with_task_that_checks_args_passed_with_spaces/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+identify = "python identify.py"

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -145,6 +145,15 @@ class PassArgumentsTestCase(TaskipyTestCase):
         self.assertSubstr(f'the argument count is 5', stdout)
         self.assertEqual(exit_code, 0)
 
+    def test_running_task_with_arguments_with_spaces(self):
+        cwd = self.create_test_dir_from_fixture('project_with_task_that_checks_args_passed_with_spaces')
+        name = 'Roy Sommer'
+        age = random.randrange(1, 100)
+        exit_code, stdout, _ = self.run_task('identify', args=['--full-name', name, '--age', f'{age}'], cwd=cwd)
+
+        self.assertSubstr(f'name: {name} age: {age}', stdout)
+        self.assertEqual(exit_code, 0)
+
     def test_running_task_arguments_not_passed_to_pre_hook(self):
         cwd = self.create_test_dir_from_fixture('project_with_tasks_that_accept_arguments')
         some_random_number = random.randint(1, 1000)


### PR DESCRIPTION
## Description
As stated by a user in the original [pr](https://github.com/illBeRoy/taskipy/pull/2#issuecomment-601922439), arguments with spaces are not passed correctly.

This was fixed, by escaping the arguments properly using `shlex`.