### PR TITLE
Add -l option for taskipy list command

### DIFF
--- a/taskipy/cli.py
+++ b/taskipy/cli.py
@@ -12,15 +12,17 @@ def main():
         prog='task',
         description='runs a task specified in your pyproject.toml under [tool.taskipy.tasks]',
     )
-    parser.add_argument('--list', help='show list of available tasks', action='store_true')
+    parser.add_argument('-l', '--list', help='show list of available tasks', action='store_true')
     parser.add_argument('name', help='name of the task', nargs='?')
     parser.add_argument('args', nargs=argparse.REMAINDER, help='arguments to pass to the task')
     args = parser.parse_args()
     try:
         runner = TaskRunner(Path.cwd() / 'pyproject.toml')
+
         if args.list:
             runner.list()
             sys.exit(0)
+
         exit_code = runner.run(args.name, args.args)
         sys.exit(exit_code)
     except TaskipyError as e:

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -178,28 +178,32 @@ class PassArgumentsTestCase(TaskipyTestCase):
 
 
 class ListTasksTestCase(TaskipyTestCase):
+    project_tasks_output = "\n".join([
+        "one    echo first task",
+        "two    echo second task",
+        "three  echo third task",
+    ])
+
     def test_running_task_list(self):
         cwd = self.create_test_dir_from_fixture('project_with_tasks_to_list')
         exit_code, stdout, _ = self.run_task('--list', cwd=cwd)
 
-        expected = "\n".join([
-            "one    echo first task",
-            "two    echo second task",
-            "three  echo third task",
-        ])
-        self.assertEqual(expected, stdout.strip())
+        self.assertEqual(self.project_tasks_output, stdout.strip())
+        self.assertEqual(exit_code, 0)
+
+    def test_running_task_list_with_shorthand(self):
+        cwd = self.create_test_dir_from_fixture('project_with_tasks_to_list')
+        exit_code, stdout, _ = self.run_task('-l', cwd=cwd)
+
+        self.assertEqual(self.project_tasks_output, stdout.strip())
         self.assertEqual(exit_code, 0)
 
     def test_running_task_list_before_name(self):
         cwd = self.create_test_dir_from_fixture('project_with_tasks_to_list')
         # anything following the flag should be ignored
         exit_code, stdout, _ = self.run_task('--list', ['one'], cwd=cwd)
-        expected = "\n".join([
-            "one    echo first task",
-            "two    echo second task",
-            "three  echo third task",
-        ])
-        self.assertEqual(expected, stdout.strip())
+
+        self.assertEqual(self.project_tasks_output, stdout.strip())
         self.assertEqual(exit_code, 0)
 
     def test_running_task_list_with_arg(self):
@@ -207,6 +211,7 @@ class ListTasksTestCase(TaskipyTestCase):
         # when --list follows after task name it should be passed as an argument
         exit_code, stdout, _ = self.run_task('one', ['--list'], cwd=cwd)
         expected = "first task --list"
+
         self.assertEqual(expected, stdout.strip())
         self.assertEqual(exit_code, 0)
 


### PR DESCRIPTION
This adds a minor enhancement to allow for running the `task --list` command as `task -l`.