### PR TITLE
Support Windows-Style Paths

### DIFF
--- a/.github/workflows/tmp_windows_job.yml
+++ b/.github/workflows/tmp_windows_job.yml
@@ -1,0 +1,28 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Taskipy Test CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+    - name: Install dependencies
+      run: poetry install
+    - name: Test
+      run: poetry run task unittest tests\test_windows_sanity.py

--- a/.github/workflows/tmp_windows_job.yml
+++ b/.github/workflows/tmp_windows_job.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Taskipy Test CI
+name: Taskipy Windows Sanity Check
 
 on:
   push:
@@ -25,4 +25,4 @@ jobs:
     - name: Install dependencies
       run: poetry install
     - name: Test
-      run: poetry run task unittest tests\test_windows_sanity.py
+      run: poetry run task run_unittest tests\test_windows_sanity.py

--- a/.github/workflows/windows_sanity.yml
+++ b/.github/workflows/windows_sanity.yml
@@ -1,4 +1,4 @@
-# This workflow checks that 
+# This workflow checks that windows paths (a\b\c) work correctly when passed as args to taskipy
 
 name: Taskipy Windows Sanity Test
 

--- a/.github/workflows/windows_sanity.yml
+++ b/.github/workflows/windows_sanity.yml
@@ -1,7 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow checks that 
 
-name: Taskipy Windows Sanity Check
+name: Taskipy Windows Sanity Test
 
 on:
   push:
@@ -25,4 +24,4 @@ jobs:
     - name: Install dependencies
       run: poetry install
     - name: Test
-      run: poetry run task run_unittest tests\test_windows_sanity.py
+      run: poetry run task run_unittest_as_windows_sanity tests\test_windows_sanity.py

--- a/.github/workflows/windows_sanity.yml
+++ b/.github/workflows/windows_sanity.yml
@@ -23,5 +23,5 @@ jobs:
         pip install poetry
     - name: Install dependencies
       run: poetry install
-    - name: Test
+    - name: Test Windows-Style Paths
       run: poetry run task run_unittest_as_windows_sanity tests\test_windows_sanity.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -55,6 +55,14 @@ python-versions = "*"
 version = "0.6.1"
 
 [[package]]
+category = "main"
+description = "shlex for windows"
+name = "mslex"
+optional = false
+python-versions = ">=3.5"
+version = "0.3.0"
+
+[[package]]
 category = "dev"
 description = "Optional static typing for Python"
 name = "mypy"
@@ -153,7 +161,7 @@ python-versions = "*"
 version = "1.12.1"
 
 [metadata]
-content-hash = "c6ae36b0ee0970891c89a2a4b5a46cba6bffc0f758710a074e5f442f46a46189"
+content-hash = "3750f1e08c9f4d634811bdd89c8d1e004df324cfbe38fb0caab6a8f7713fcf33"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -195,6 +203,10 @@ lazy-object-proxy = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mslex = [
+    {file = "mslex-0.3.0-py2.py3-none-any.whl", hash = "sha256:380cb14abf8fabf40e56df5c8b21a6d533dc5cbdcfe42406bbf08dda8f42e42a"},
+    {file = "mslex-0.3.0.tar.gz", hash = "sha256:4a1ac3f25025cad78ad2fe499dd16d42759f7a3801645399cce5c404415daa97"},
 ]
 mypy = [
     {file = "mypy-0.761-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6"},
@@ -254,19 +266,28 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typing-extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ task = 'taskipy.cli:main'
 python = "^3.6"
 toml = "^0.10.0"
 psutil = "^5.7.2"
+mslex = "^0.3.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4.4"
@@ -48,6 +49,8 @@ publish_patch = "poetry version patch && ./task publish"
 
 pre_publish_minor = "./task test"
 publish_minor = "poetry version minor && ./task publish"
+
+run_unittest = "unittest -v"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ publish_patch = "poetry version patch && ./task publish"
 pre_publish_minor = "./task test"
 publish_minor = "poetry version minor && ./task publish"
 
-run_unittest = "unittest -v"
+run_unittest = "python -m unittest -v"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ psutil = "^5.6.7"
 test = "python -m unittest -v tests/test_*.py"
 post_test = "./task lint"
 
+run_unittest_as_windows_sanity = "python -m unittest -v"
+
 lint = "./task lint_pylint && ./task lint_mypy"
 lint_pylint = "pylint tests taskipy"
 lint_mypy = "mypy tests taskipy"
@@ -49,8 +51,6 @@ publish_patch = "poetry version patch && ./task publish"
 
 pre_publish_minor = "./task test"
 publish_minor = "poetry version minor && ./task publish"
-
-run_unittest = "python -m unittest -v"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -66,6 +66,6 @@ class Task:
             return None
 
     def __quote_arg(self, arg: str) -> str:
-        # if platform.system() == 'Windows':
-            # return mslex.quote(arg)
+        if platform.system() == 'Windows':
+            return mslex.quote(arg)
         return shlex.quote(arg)

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -1,4 +1,6 @@
+import platform
 import shlex
+import mslex
 from typing import Optional, List
 
 from taskipy.exceptions import (
@@ -32,7 +34,7 @@ class Task:
             command = self.project.tasks[self.name]
             commands = []
             commands.append(
-                ' '.join([command] + [shlex.quote(arg) for arg in self.args])
+                ' '.join([command] + [self.__quote_arg(arg) for arg in self.args])
             )
 
             if self.pre_task:
@@ -62,3 +64,8 @@ class Task:
             return self.project.tasks[f'{hook_type}_{self.name}']
         except KeyError:
             return None
+
+    def __quote_arg(self, arg: str) -> str:
+        # if platform.system() == 'Windows':
+            # return mslex.quote(arg)
+        return shlex.quote(arg)

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -1,6 +1,6 @@
 import platform
 import shlex
-import mslex
+import mslex # type: ignore
 from typing import Optional, List
 
 from taskipy.exceptions import (

--- a/tests/fixtures/project_with_windows_task/pyproject.toml
+++ b/tests/fixtures/project_with_windows_task/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+echo = "echo"

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -341,14 +341,3 @@ class CustomRunnerTestCase(TaskipyTestCase):
 
         self.assertSubstr('invalid value: runner is not a string. please check [tool.taskipy.settings.runner]', stdout)
         self.assertEqual(exit_code, 1)
-
-
-class WindowsArgumentHandlingTestCase(TaskipyTestCase):
-    @patch('platform.system')
-    def test_pass_windows_args_correctly(self, platform_system_mock: MagicMock):
-        platform_system_mock.return_value = 'Windows'
-        cwd = self.create_test_dir_from_fixture('project_with_windows_task')
-        exit_code, stdout, _ = self.run_task('echo', args=['hello', 'some\\windows\\path'], cwd=cwd)
-
-        self.assertEqual(stdout.strip(), 'hello some\\windows\\path')
-        self.assertEqual(exit_code, 0)

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -7,7 +7,6 @@ import unittest
 import warnings
 import psutil  # type: ignore
 from os import path
-from unittest.mock import patch, MagicMock
 from typing import List, Tuple
 
 from tests.utils.project import (

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -5,10 +5,10 @@ import subprocess
 import time
 import unittest
 import warnings
-from os import path
-from typing import List, Tuple
-
 import psutil  # type: ignore
+from os import path
+from unittest.mock import patch, MagicMock
+from typing import List, Tuple
 
 from tests.utils.project import (
     GenerateProjectFromFixture,
@@ -341,3 +341,14 @@ class CustomRunnerTestCase(TaskipyTestCase):
 
         self.assertSubstr('invalid value: runner is not a string. please check [tool.taskipy.settings.runner]', stdout)
         self.assertEqual(exit_code, 1)
+
+
+class WindowsArgumentHandlingTestCase(TaskipyTestCase):
+    @patch('platform.system')
+    def test_pass_windows_args_correctly(self, platform_system_mock: MagicMock):
+        platform_system_mock.return_value = 'Windows'
+        cwd = self.create_test_dir_from_fixture('project_with_windows_task')
+        exit_code, stdout, _ = self.run_task('echo', args=['hello', 'some\\windows\\path'], cwd=cwd)
+
+        self.assertEqual(stdout.strip(), 'hello some\\windows\\path')
+        self.assertEqual(exit_code, 0)

--- a/tests/test_windows_sanity.py
+++ b/tests/test_windows_sanity.py
@@ -1,0 +1,5 @@
+import unittest
+
+class WindowsSanityTestCase(unittest.TestCase):
+    def test_windows_sanity(self):
+        print('ok, working :)')

--- a/tests/test_windows_sanity.py
+++ b/tests/test_windows_sanity.py
@@ -1,5 +1,11 @@
 import unittest
 
+
 class WindowsSanityTestCase(unittest.TestCase):
+    '''
+    This test case is a no-op, and exists only to ensure that windows paths work
+    as part of the windows sanity ci test.
+    '''
+
     def test_windows_sanity(self):
-        print('ok, working :)')
+        print('sanity passed - test was run')


### PR DESCRIPTION
## Description
This PR should fix the way arguments are handled on windows. It uses `mslex` instead of the posix-oriented `shlex` library that we use by default.

This should solve any issues regarding to windows-style paths passed as arguments to taskipy, when running in windows environment.

In addition, I've added a new CI flow that specifically checks path handling on windows.