### PR TITLE
Find a parent pyproject.toml from a child directory

### DIFF
--- a/taskipy/cli.py
+++ b/taskipy/cli.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument('args', nargs=argparse.REMAINDER, help='arguments to pass to the task')
     args = parser.parse_args()
     try:
-        runner = TaskRunner(Path.cwd() / 'pyproject.toml')
+        runner = TaskRunner(Path.cwd())
 
         if args.list:
             runner.list()

--- a/taskipy/exceptions.py
+++ b/taskipy/exceptions.py
@@ -12,7 +12,7 @@ class InvalidRunnerTypeError(TaskipyError):
 
 class MissingPyProjectFileError(TaskipyError):
     def __str__(self):
-        return 'no pyproject.toml file found in this directory'
+        return 'no pyproject.toml file found in this directory or parent directories'
 
 
 class MalformedPyProjectError(TaskipyError):

--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -12,8 +12,9 @@ from taskipy.exceptions import (
 
 
 class PyProject:
-    def __init__(self, file_path: Union[str, Path]):
-        self.__items = PyProject.__load_toml_file(file_path)
+    def __init__(self, base_dir: Path):
+        pyproject_path = self.__find_pyproject_path(base_dir)
+        self.__items = PyProject.__load_toml_file(pyproject_path)
 
     @property
     def tasks(self) -> dict:
@@ -40,3 +41,15 @@ class PyProject:
             raise MissingPyProjectFileError()
         except toml.TomlDecodeError:
             raise MalformedPyProjectError()
+
+    @staticmethod
+    def __find_pyproject_path(base_dir: Path) -> Path:
+        def candidate_dirs(base: Path):
+            yield base
+            for parent in base.parents:
+                yield parent
+        for candidate_dir in candidate_dirs(base_dir):
+            pyproject = candidate_dir / 'pyproject.toml'
+            if pyproject.exists():
+                return pyproject
+        raise MissingPyProjectFileError()

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -11,9 +11,10 @@ from taskipy.task import Task
 
 
 class TaskRunner:
-    def __init__(self, pyproject_path: Union[str, Path]):
-        self.__pyproject_path = pyproject_path
-        self.project = PyProject(pyproject_path)
+    def __init__(self, cwd: Union[str, Path]):
+        working_dir = cwd if isinstance(cwd, Path) else Path(cwd)
+        self.__working_dir = working_dir
+        self.project = PyProject(working_dir)
 
     def list(self):
         """lists tasks to stdout"""
@@ -28,7 +29,7 @@ class TaskRunner:
             if task.runner is not None:
                 command = f'{task.runner} {command}'
             process = subprocess.Popen(
-                command, shell=True, cwd=Path(self.__pyproject_path).parent
+                command, shell=True, cwd=self.__working_dir
             )
 
             def send_signal_to_task_process(signum: int, frame) -> None:  # pylint: disable=unused-argument

--- a/tests/fixtures/project_with_tasks_from_child/child_with_pyproject/pyproject.toml
+++ b/tests/fixtures/project_with_tasks_from_child/child_with_pyproject/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+hello = 'echo "hello from child"'

--- a/tests/fixtures/project_with_tasks_from_child/pyproject.toml
+++ b/tests/fixtures/project_with_tasks_from_child/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+print_current_dir_name = 'python -c "from pathlib import Path; print(Path.cwd().name)"'

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -94,7 +94,6 @@ class RunTaskTestCase(TaskipyTestCase):
 
         self.assertSubstr('hello stderr', stderr)
 
-
 class TaskPrePostHooksTestCase(TaskipyTestCase):
     def test_running_pre_task_hook(self):
         cwd = self.create_test_dir_from_fixture('project_with_pre_post_task_hooks')
@@ -234,7 +233,7 @@ class TaskRunFailTestCase(TaskipyTestCase):
         cwd = self.create_test_dir_from_fixture('project_without_pyproject')
         exit_code, stdout, _ = self.run_task('some_task', cwd=cwd)
 
-        self.assertSubstr('no pyproject.toml file found in this directory', stdout)
+        self.assertSubstr('no pyproject.toml file found in this directory or parent directories', stdout)
         self.assertEqual(exit_code, 1)
 
     def test_exiting_with_code_1_and_printing_if_pyproject_toml_file_is_malformed(self):
@@ -340,3 +339,17 @@ class CustomRunnerTestCase(TaskipyTestCase):
 
         self.assertSubstr('invalid value: runner is not a string. please check [tool.taskipy.settings.runner]', stdout)
         self.assertEqual(exit_code, 1)
+
+
+class TaskFromChildTestCase(TaskipyTestCase):
+    def test_running_parent_pyproject_task_from_child_directory(self):
+        cwd = self.create_test_dir_from_fixture('project_with_tasks_from_child')
+        _, stdout, _ = self.run_task('print_current_dir_name', cwd=path.join(cwd, 'child_without_pyproject'))
+
+        self.assertSubstr('child_without_pyproject', stdout)
+
+    def test_find_nearest_pyproject_from_child_directory(self):
+        cwd = self.create_test_dir_from_fixture('project_with_tasks_from_child')
+        _, stdout, _ = self.run_task('hello', cwd=path.join(cwd, 'child_with_pyproject'))
+
+        self.assertSubstr('hello from child', stdout)


### PR DESCRIPTION
## Description

Currently, `taskipy` finds `pyproject.toml` only in the current working directory.

This PR makes `taskipy` to find `pyproject.toml` in the current working directory and its parent directories.
So `taskipy` can run the task from child directories which doesn't include `pyproject.toml`.

## Changes

- `TaskRunner` uses the current working directory when it runs the specified task.
- `PyProject` finds `pyproject.toml` in the current working directory and its parent directories.
- Added relevant test cases under `TestFromChildTestCase` (in test_taskipy.py)
