### PR TITLE
Add variable support

### DIFF
--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -8,8 +8,7 @@ from taskipy.exceptions import (
     InvalidRunnerTypeError,
     MalformedPyProjectError,
     MissingPyProjectFileError,
-    MissingTaskipyTasksSectionError,
-    MissingTaskipySettingsSectionError
+    MissingTaskipyTasksSectionError
 )
 
 

--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -28,6 +28,10 @@ class PyProject:
             raise MissingTaskipyTasksSectionError()
 
     @property
+    def variables(self) -> Dict[str, Task]:
+        return self.__items['tool']['taskipy'].get('variables', {})
+
+    @property
     def settings(self) -> dict:
         try:
             return self.__items['tool']['taskipy']['settings']

--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -39,7 +39,7 @@ class PyProject:
         try:
             return self.__items['tool']['taskipy']['settings']
         except KeyError:
-            raise MissingTaskipySettingsSectionError()
+            return {}
 
     @property
     def runner(self) -> Optional[str]:

--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -49,7 +49,7 @@ class PyProject:
                 raise InvalidRunnerTypeError()
 
             return runner.strip()
-        except (KeyError, MissingTaskipySettingsSectionError):
+        except KeyError:
             return None
 
     @staticmethod

--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -29,7 +29,10 @@ class PyProject:
 
     @property
     def variables(self) -> Dict[str, Task]:
-        return self.__items['tool']['taskipy'].get('variables', {})
+        try:
+            return self.__items['tool']['taskipy'].get('variables', {})
+        except KeyError:
+            return {}
 
     @property
     def settings(self) -> dict:

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -6,6 +6,7 @@ class Task:
         self.__task_name = task_name
         self.__task_command = self.__extract_task_command(task_toml_contents)
         self.__task_description = self.__extract_task_description(task_toml_contents)
+        self.__task_user_vars = self.__extract_task_use_vars(task_toml_contents)
 
     @property
     def name(self):
@@ -19,6 +20,20 @@ class Task:
     def description(self):
         return self.__task_description
 
+    @property
+    def use_vars(self):
+        return self.__task_user_vars
+
+    def __extract_task_use_vars(self, task_toml_contents: object) -> bool:
+        if isinstance(task_toml_contents, str):
+            return False
+        if isinstance(task_toml_contents, dict):
+            try:
+                return task_toml_contents['use_vars']
+            except KeyError:
+                return False
+        raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help, use_vars }')
+
     def __extract_task_command(self, task_toml_contents: object) -> str:
         if isinstance(task_toml_contents, str):
             return task_toml_contents
@@ -29,7 +44,7 @@ class Task:
             except KeyError:
                 raise MalformedTaskError(self.__task_name, 'the task item does not have the "cmd" property')
 
-        raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help }')
+        raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help, use_vars }')
 
     def __extract_task_description(self, task_toml_contents: object) -> str:
         if isinstance(task_toml_contents, str):
@@ -41,4 +56,4 @@ class Task:
             except KeyError:
                 return ''
 
-        raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help }')
+        raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help, use_vars}')

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -22,16 +22,19 @@ class Task:
 
     @property
     def use_vars(self):
-        return self.__task_user_vars
+        return self.__task_use_vars
 
     def __extract_task_use_vars(self, task_toml_contents: object) -> bool:
         if isinstance(task_toml_contents, str):
             return False
         if isinstance(task_toml_contents, dict):
             try:
-                return task_toml_contents['use_vars']
+                value = task_toml_contents['use_vars']
             except KeyError:
                 return False
+            if not isinstance(value, bool):
+                raise MalformedTaskError(self.__task_name, f'task\'s "use_vars" arg has to be bool type got {type(value)}')
+            return value
         raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help, use_vars }')
 
     def __extract_task_command(self, task_toml_contents: object) -> str:

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -6,7 +6,7 @@ class Task:
         self.__task_name = task_name
         self.__task_command = self.__extract_task_command(task_toml_contents)
         self.__task_description = self.__extract_task_description(task_toml_contents)
-        self.__task_user_vars = self.__extract_task_use_vars(task_toml_contents)
+        self.__task_use_vars = self.__extract_task_use_vars(task_toml_contents)
 
     @property
     def name(self):

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -56,6 +56,8 @@ class TaskRunner:
         if args is None:
             args = []
 
+        command = command.format(**self.__project.variables)
+
         if self.__project.runner is not None:
             command = f'{self.__project.runner} {command}'
 

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -57,7 +57,7 @@ class TaskRunner:
             args = []
 
         command = task.command
-        if task.use_vars or self.__project.settings.get('use_vars'):
+        if task.use_vars or self.__project.settings.get('use_vars', {}):
             try:
                 command = command.format(**self.__project.variables)
             except KeyError as e:

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -57,7 +57,7 @@ class TaskRunner:
             args = []
 
         command = task.command
-        if task.use_vars:
+        if task.use_vars or self.__project.settings.get('use_vars'):
             try:
                 command = command.format(**self.__project.variables)
             except KeyError as e:

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -36,27 +36,29 @@ class TaskRunner:
 
         pre_task = self.__pre_task(task_name)
         if pre_task is not None:
-            exit_code = self.__run_command_and_return_exit_code(pre_task.command)
+            exit_code = self.__run_command_and_return_exit_code(pre_task)
             if exit_code != 0:
                 return exit_code
 
-        exit_code = self.__run_command_and_return_exit_code(task.command, args)
+        exit_code = self.__run_command_and_return_exit_code(task, args)
         if exit_code != 0:
             return exit_code
 
         post_task = self.__post_task(task_name)
         if post_task is not None:
-            exit_code = self.__run_command_and_return_exit_code(post_task.command)
+            exit_code = self.__run_command_and_return_exit_code(post_task)
             if exit_code != 0:
                 return exit_code
 
         return 0
 
-    def __run_command_and_return_exit_code(self, command: str, args: List[str] = None) -> int:
+    def __run_command_and_return_exit_code(self, task: Task, args: List[str] = None) -> int:
         if args is None:
             args = []
 
-        command = command.format(**self.__project.variables)
+        command = task.command
+        if task.use_vars:
+            command = command.format(**self.__project.variables)
 
         if self.__project.runner is not None:
             command = f'{self.__project.runner} {command}'

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Union, Optional
 
 from taskipy.pyproject import PyProject
-from taskipy.exceptions import TaskNotFoundError
+from taskipy.exceptions import TaskNotFoundError, MalformedTaskError
 from taskipy.task import Task
 from taskipy.help import HelpFormatter
 
@@ -58,7 +58,10 @@ class TaskRunner:
 
         command = task.command
         if task.use_vars:
-            command = command.format(**self.__project.variables)
+            try:
+                command = command.format(**self.__project.variables)
+            except KeyError as e:
+                raise MalformedTaskError(task.name, f"{e} variable expected in [pyproject.taskipy.variables]")
 
         if self.__project.runner is not None:
             command = f'{self.__project.runner} {command}'

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -272,7 +272,7 @@ class TaskDescriptionTestCase(TaskipyTestCase):
         exit_code, stdout, _ = self.run_task('print_age', cwd=cwd)
 
         self.assertEqual(exit_code, 1)
-        self.assertSubstr('tasks must be strings, or dicts that contain { cmd, help }', stdout)
+        self.assertSubstr('tasks must be strings, or dicts that contain { cmd, help, use_vars }', stdout)
 
 
 class TaskRunFailTestCase(TaskipyTestCase):

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -506,3 +506,19 @@ class UseVarsTestCase(TaskipyTestCase):
         exit_code, stdout, _ = self.run_task('echo', cwd=cwd)
         self.assertSubstr("reason: 'name' variable expected in [pyproject.taskipy.variables", stdout)
         self.assertEqual(exit_code, 1)
+
+    def test_use_vars_setting(self):
+        py_project_toml = '''
+            [tool.taskipy.settings]
+            use_vars = true
+
+            [tool.taskipy.variables]
+            name = "John Doe"
+
+            [tool.taskipy.tasks]
+            echo = "echo hello {name:<10}:"
+        '''
+        cwd = self.create_test_dir_with_py_project_toml(py_project_toml)
+        exit_code, stdout, _ = self.run_task('echo', cwd=cwd)
+        self.assertSubstr('hello John Doe :', stdout)
+        self.assertEqual(exit_code, 0)


### PR DESCRIPTION
As per https://github.com/illBeRoy/taskipy/issues/37 

What if we added variable support?

```
[tool.taskipy.variables]
name = "John Doe"

[tool.taskipy.tasks]
echo = "echo hello {name}, how are you?"
```

Only negative here would be that `{}` would be reserved character for commands (could be escaped by `{{}}`, e.g. `echo {{name}}` wil resolve to `echo {name}`).   
Generally I don't know any commands that use curly braces but I can imagine some weird `sed` commands or something like that could break. 

Alternatively we could also expand variables to process env so command could just reference variable `echo = "echo hello $NAME, how are you?"` which would be safer though would lose python f-string templating.