### PR TITLE
Fix `taskipy.variables` table name in error message

### DIFF
--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -61,7 +61,7 @@ class TaskRunner:
             try:
                 command = command.format(**self.__project.variables)
             except KeyError as e:
-                raise MalformedTaskError(task.name, f"{e} variable expected in [pyproject.taskipy.variables]")
+                raise MalformedTaskError(task.name, f"{e} variable expected in [tool.taskipy.variables]")
 
         if self.__project.runner is not None:
             command = f'{self.__project.runner} {command}'

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -504,7 +504,7 @@ class UseVarsTestCase(TaskipyTestCase):
         '''
         cwd = self.create_test_dir_with_py_project_toml(py_project_toml)
         exit_code, stdout, _ = self.run_task('echo', cwd=cwd)
-        self.assertSubstr("reason: 'name' variable expected in [pyproject.taskipy.variables", stdout)
+        self.assertSubstr("reason: 'name' variable expected in [tool.taskipy.variables", stdout)
         self.assertEqual(exit_code, 1)
 
     def test_use_vars_setting(self):


### PR DESCRIPTION
If a task is using a variable that doesn't exist, it currently reports that it isn't found in `[pyproject.taskipy.variables]` whereas it should be reporting that it isn't found in `[tool.taskipy.variables]`.