### PR TITLE
Fix logo image on readme to work on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./logo.svg" width="150" />
+  <img src="https://github.com/illBeRoy/taskipy/raw/master/logo.svg" width="150" />
 </p>
 
 - [General](#general)


### PR DESCRIPTION
It looks like I had broken the logo image on the PyPI entry for the project with [this change](https://github.com/illBeRoy/taskipy/commit/8ee47d5a4db18d9aa5a8fcac2cd90c8f360266d3). I must not have considered that when I made it.

Adding this here to correct my mistake :slightly_smiling_face: 