### PR TITLE
Allow tomli version 2 to be used

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -157,6 +157,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "typed-ast"
 version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
@@ -183,7 +191,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "0f2902f0dc8c20fa5616e38c240226e931e782e1647369e0549e33982a387a11"
+content-hash = "f96808533648d3f2a4c7620767f2117a2a961057fa8a250bdf1420519a78737a"
 
 [metadata.files]
 astroid = [
@@ -331,6 +339,8 @@ toml = [
 tomli = [
     {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ task = 'taskipy.cli:main'
 
 [tool.poetry.dependencies]
 python = "^3.6"
-tomli = "^1.2.3"
+tomli = [
+    { version = "^2.0.1", python = "^3.7" },
+    { version = "^1.2.3", python = "~3.6" }
+]
 psutil = "^5.7.2"
 mslex = { version = "^0.3.0", markers = "sys_platform == 'win32'" }
 colorama = "^0.4.4"


### PR DESCRIPTION
The current dependency specification disallows versions of tomli >=2, looking at the code that was changed #43, it don't look like any issues could be caused by allowing its use