### PR TITLE
Add tomli test case for different python versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -157,6 +157,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "typed-ast"
 version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
@@ -166,7 +174,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.1"
+version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "dev"
 optional = false
@@ -183,7 +191,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "0f2902f0dc8c20fa5616e38c240226e931e782e1647369e0549e33982a387a11"
+content-hash = "f96808533648d3f2a4c7620767f2117a2a961057fa8a250bdf1420519a78737a"
 
 [metadata.files]
 astroid = [
@@ -331,6 +339,8 @@ toml = [
 tomli = [
     {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -365,8 +375,8 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
-    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 wrapt = [
     {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ task = 'taskipy.cli:main'
 
 [tool.poetry.dependencies]
 python = "^3.6"
-tomli = "^1.2.3"
+tomli = [
+    { version = "^2.0.1", python = "^3.7" },
+    { version = "^1.2.3", python = "~3.6" }
+]
 psutil = "^5.7.2"
 mslex = { version = "^0.3.0", markers = "sys_platform == 'win32'" }
 colorama = "^0.4.4"

--- a/tests/test_tomli_install.py
+++ b/tests/test_tomli_install.py
@@ -1,0 +1,49 @@
+import subprocess
+import sys
+import unittest
+from typing import Dict, List, Tuple
+
+
+class TomliInstallTestCase(unittest.TestCase):
+    def test_correct_tomli_version_installed(self):
+        python_major, python_minor = self._get_current_python_version()
+        packages = self._get_installed_pip_packages()
+        tomli_version = packages.get('tomli')
+        v1_regex = r'1.[0-9]+.[0-9]+'
+        v2_regex = r'2.[0-9]+.[0-9]+'
+
+        if python_major == 3 and python_minor == 6:
+            self.assertRegex(tomli_version, v1_regex)
+        elif python_major == 3 and python_minor >= 7:
+            self.assertRegex(tomli_version, v2_regex)
+        else:
+            self.fail("Executed with invalid Python version")
+
+    def _get_current_python_version(self) -> Tuple[int, int]:
+        python_version = sys.version_info
+
+        return python_version.major, python_version.minor
+
+    def _get_installed_pip_packages(self) -> Dict[str, str]:
+        cmd = "pip list"
+        process = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        exit_code = process.returncode
+        if exit_code != 0:
+            raise RuntimeError(
+                'listing pip packages got a non-zero exit code'
+            )
+
+        result = {}
+        packages = self._remove_pip_list_table_header(stdout.splitlines())
+        for package in packages:
+            decoded_package = package.decode('utf-8')
+            name, version = decoded_package.split()
+            result[name] = version
+
+        return result
+
+    def _remove_pip_list_table_header(self, lines: List[bytes]) -> List[bytes]:
+        return lines[2:]

--- a/tests/test_tomli_install.py
+++ b/tests/test_tomli_install.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Tuple
 
 class TomliInstallTestCase(unittest.TestCase):
     def test_correct_tomli_version_installed(self):
-        python_major, python_minor = self._get_current_python_version()
-        packages = self._get_installed_pip_packages()
+        python_major, python_minor = self.__get_current_python_version()
+        packages = self.__get_installed_pip_packages()
         tomli_version = packages.get('tomli')
         v1_regex = r'1.[0-9]+.[0-9]+'
         v2_regex = r'2.[0-9]+.[0-9]+'
@@ -19,12 +19,12 @@ class TomliInstallTestCase(unittest.TestCase):
         else:
             self.fail("Executed with invalid Python version")
 
-    def _get_current_python_version(self) -> Tuple[int, int]:
+    def __get_current_python_version(self) -> Tuple[int, int]:
         python_version = sys.version_info
 
         return python_version.major, python_version.minor
 
-    def _get_installed_pip_packages(self) -> Dict[str, str]:
+    def __get_installed_pip_packages(self) -> Dict[str, str]:
         cmd = "pip list"
         process = subprocess.Popen(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -37,7 +37,7 @@ class TomliInstallTestCase(unittest.TestCase):
             )
 
         result = {}
-        packages = self._remove_pip_list_table_header(stdout.splitlines())
+        packages = self.__remove_pip_list_table_header(stdout.splitlines())
         for package in packages:
             decoded_package = package.decode('utf-8')
             name, version = decoded_package.split()
@@ -45,5 +45,5 @@ class TomliInstallTestCase(unittest.TestCase):
 
         return result
 
-    def _remove_pip_list_table_header(self, lines: List[bytes]) -> List[bytes]:
+    def __remove_pip_list_table_header(self, lines: List[bytes]) -> List[bytes]:
         return lines[2:]


### PR DESCRIPTION
This adds a test case for the tomli install for #46. Since we're already running these tests on CI on a number of various python versions that are supported, this adds a test case along side those to make sure that the test case for Python 3.6 has the tomli v1 version installed when it runs and 3.7+ has the v2 version installed.

Let me know if this works! We would probably want to merge in #46 first, rebase this branch to pull in those changes, and then merge in this test case? I had to copy-paste the change from that PR here so I could actually run the test case and have it pass.