### PR TITLE
Gracefully handle "task --list" when there are no tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.tabSize": 4,
   "python.linting.enabled": true,
   "python.linting.pylintEnabled": true,
-  "python.linting.mypyEnabled": true
+  "python.linting.mypyEnabled": true,
+  "python.formatting.provider": "none"
 }

--- a/taskipy/exceptions.py
+++ b/taskipy/exceptions.py
@@ -81,6 +81,16 @@ class MissingTaskipyTasksSectionError(TaskipyError):
         )
 
 
+class EmptyTasksSectionError(TaskipyError):
+    exit_code = 127
+
+    def __str__(self):
+        return (
+            'no tasks found. create your first task '
+            'by adding it to your pyproject.toml file under [tool.taskipy.tasks]'
+        )
+
+
 class CircularVariableError(TaskipyError):
     exit_code = 127
 

--- a/taskipy/list.py
+++ b/taskipy/list.py
@@ -4,14 +4,18 @@ import colorama # type: ignore
 from typing import List
 
 from taskipy.task import Task
+from taskipy.exceptions import EmptyTasksSectionError
 
 
-class HelpFormatter:
+class TasksListFormatter:
     def __init__(self, tasks: List[Task]):
         self.__tasks = tasks
 
     def print(self, line_width=shutil.get_terminal_size().columns):
         colorama.init()
+
+        if not self.__tasks:
+            raise EmptyTasksSectionError()
 
         tasks_col = [task.name for task in self.__tasks]
         longest_item_in_tasks_col = len(max(tasks_col, key=len))

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, List, Tuple, Union, Optional
 import psutil  # type: ignore
 
 from taskipy.exceptions import CircularVariableError, TaskNotFoundError, MalformedTaskError
-from taskipy.help import HelpFormatter
+from taskipy.list import TasksListFormatter
 from taskipy.pyproject import PyProject
 from taskipy.task import Task
 from taskipy.variable import Variable
@@ -28,7 +28,7 @@ class TaskRunner:
 
     def list(self):
         """lists tasks to stdout"""
-        formatter = HelpFormatter(self.__project.tasks.values())
+        formatter = TasksListFormatter(self.__project.tasks.values())
         formatter.print()
 
     def run(self, task_name: str, args: List[str]) -> int:

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -221,6 +221,24 @@ class ListTasksTestCase(TaskipyTestCase):
         self.assertTerminalTextEqual(expected, stdout.strip())
         self.assertEqual(exit_code, 0)
 
+    def test_running_task_list_no_tasks(self):
+        py_project_toml = '''
+            [tool.taskipy.tasks]
+        '''
+        cwd = self.create_test_dir_with_py_project_toml(py_project_toml)
+        exit_code, stdout, _ = self.run_task('--list', cwd=cwd)
+
+        self.assertTerminalTextEqual('no tasks found. create your first task by adding it to your pyproject.toml file under [tool.taskipy.tasks]', stdout.strip())
+        self.assertEqual(exit_code, 127)
+
+    def test_running_task_list_no_tasks_section(self):
+        py_project_toml = ''
+        cwd = self.create_test_dir_with_py_project_toml(py_project_toml)
+        exit_code, stdout, _ = self.run_task('--list', cwd=cwd)
+
+        self.assertTerminalTextEqual('no tasks found. add a [tool.taskipy.tasks] section to your pyproject.toml', stdout.strip())
+        self.assertEqual(exit_code, 127)
+
 
 class TaskDescriptionTestCase(TaskipyTestCase):
     def test_running_task_with_description(self):


### PR DESCRIPTION
## Description
This PR adds graceful handling of the `task --list` command under two circumstances:

One: There is no "tasks" section in `pyproject.toml`:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/6681893/187537160-3ce3d782-7376-4de6-aa63-ec945508eeec.png">

Two: The "tasks" section is empty:
<img width="764" alt="image" src="https://user-images.githubusercontent.com/6681893/187537255-f2c6a82f-d463-4e11-ad11-0f24bf65c0fc.png">

This also fixes issue #51 

## Changes
1. Created two new test cases under `ListTasksTestCase` for each edge case
2. Created a new exception class: `EmptyTasksSectionError`
3. Updated `HelpFormatter` to raise the aforementioned exception in case the tasks list is empty
4. Renamed `HelpFormatter` into `TasksListFormatter` to better emphasize its role in the system (also renamed file from `help.py` to `list.py`)