### PR TITLE
Fix Tomli Version test

### DIFF
--- a/tests/test_tomli_install.py
+++ b/tests/test_tomli_install.py
@@ -41,7 +41,8 @@ class TomliInstallTestCase(unittest.TestCase):
         print('#### DEBUG DATA ####')
         for package in packages:
             decoded_package = package.decode('utf-8')
-            print(package)
+            print(decoded_package)
+            print(decoded_package.split())
             name, version = decoded_package.split()
             result[name] = version
 

--- a/tests/test_tomli_install.py
+++ b/tests/test_tomli_install.py
@@ -38,8 +38,10 @@ class TomliInstallTestCase(unittest.TestCase):
 
         result = {}
         packages = self.__remove_pip_list_table_header(stdout.splitlines())
+        print('#### DEBUG DATA ####')
         for package in packages:
             decoded_package = package.decode('utf-8')
+            print(package)
             name, version = decoded_package.split()
             result[name] = version
 

--- a/tests/test_tomli_install.py
+++ b/tests/test_tomli_install.py
@@ -38,12 +38,9 @@ class TomliInstallTestCase(unittest.TestCase):
 
         result = {}
         packages = self.__remove_pip_list_table_header(stdout.splitlines())
-        print('#### DEBUG DATA ####')
         for package in packages:
             decoded_package = package.decode('utf-8')
-            print(decoded_package)
-            print(decoded_package.split())
-            name, version = decoded_package.split()
+            name, version, *_ = decoded_package.split()
             result[name] = version
 
         return result


### PR DESCRIPTION
## Description
Tomli version test started failing on github actions but not locally. Trying to identify why.

Turns out that [poetry 1.2.0](https://python-poetry.org/blog/announcing-poetry-1.2.0/) (released 8/31) changed its install scripts. I'm not sure what's really changed but it made pip list `taskipy` together with its version **and** path, which made the test fail on the following line:

```py
name, version = decoded_package.split()
```

since now `taskipy` has both name, version, and path.

I changed the line into

```py
name, version, *_ = decoded_package.split()
```

Which makes the test work as expected now.

**Since the change was introduced in poetry 1.2.0, it only affected the github actions run and not my local machine, which runs 1.1.x**