### PR TITLE
style(imports): Conform to PEP8

### DIFF
--- a/taskipy/cli.py
+++ b/taskipy/cli.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from taskipy.exceptions import TaskipyError, InvalidUsageError
+from taskipy.exceptions import InvalidUsageError, TaskipyError
 from taskipy.task_runner import TaskRunner
 
 

--- a/taskipy/exceptions.py
+++ b/taskipy/exceptions.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from typing import Optional
 
+
 class TaskipyError(Exception):
     exit_code = 1
 

--- a/taskipy/list.py
+++ b/taskipy/list.py
@@ -1,10 +1,11 @@
 import shutil
 import textwrap
-import colorama # type: ignore
 from typing import List
 
-from taskipy.task import Task
+import colorama  # type: ignore
+
 from taskipy.exceptions import EmptyTasksSectionError
+from taskipy.task import Task
 
 
 class TasksListFormatter:

--- a/taskipy/pyproject.py
+++ b/taskipy/pyproject.py
@@ -1,10 +1,8 @@
-import tomli
-
 from pathlib import Path
 from typing import Any, Dict, MutableMapping, Optional, Union
 
-from taskipy.task import Task
-from taskipy.variable import Variable
+import tomli
+
 from taskipy.exceptions import (
     InvalidRunnerTypeError,
     InvalidVariableError,
@@ -12,6 +10,8 @@ from taskipy.exceptions import (
     MissingPyProjectFileError,
     MissingTaskipyTasksSectionError,
 )
+from taskipy.task import Task
+from taskipy.variable import Variable
 
 
 class PyProject:

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -1,14 +1,18 @@
-import sys
 import platform
 import signal
 import subprocess
+import sys
 from pathlib import Path
 from types import FrameType
-from typing import Callable, Dict, List, Tuple, Union, Optional
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import psutil  # type: ignore
 
-from taskipy.exceptions import CircularVariableError, TaskNotFoundError, MalformedTaskError
+from taskipy.exceptions import (
+    CircularVariableError,
+    MalformedTaskError,
+    TaskNotFoundError,
+)
 from taskipy.list import TasksListFormatter
 from taskipy.pyproject import PyProject
 from taskipy.task import Task

--- a/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_without_sigint_handler.py
+++ b/tests/fixtures/project_with_tasks_that_handle_interrupts/loop_without_sigint_handler.py
@@ -1,5 +1,6 @@
-import time
 import sys
+import time
+
 
 def main():
     try:

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -8,13 +8,13 @@ import warnings
 from os import path
 from typing import List, Tuple
 
-from parameterized import parameterized  # type: ignore
 import psutil  # type: ignore
+from parameterized import parameterized  # type: ignore
 
 from tests.utils.project import (
     GenerateProjectFromFixture,
     GenerateProjectWithPyProjectToml,
-    TempProjectDir
+    TempProjectDir,
 )
 
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,5 +1,4 @@
 import platform
-
 import unittest
 
 

--- a/tests/utils/project.py
+++ b/tests/utils/project.py
@@ -1,8 +1,9 @@
-import tempfile
-import shutil
 import os
-from os import path
+import shutil
+import tempfile
 from abc import abstractmethod
+from os import path
+
 
 class ProjectDirGenerator:
     @abstractmethod


### PR DESCRIPTION
https://peps.python.org/pep-0008/#imports

A small thing I had noticed when taking a look at adding the variables to the task list output. Some of the imports aren't in the typical format of being in alphabetical order or in standard library imports then third party then first party.